### PR TITLE
fixed naming convention issue !deploy

### DIFF
--- a/PSRedgate/private/Get-SQLServerDatabaseFile.ps1
+++ b/PSRedgate/private/Get-SQLServerDatabaseFile.ps1
@@ -26,12 +26,12 @@ function Get-SQLServerDatabaseFile
         There might be more than one file for either of these. The file ordinal will tell you the file index.
 
     .EXAMPLE
-        Get-SQLServerDatabaseFiles -SQLServerName SQLEXAMPLE1 -DatabaseName ExampleDB
+        Get-SQLServerDatabaseFile -SQLServerName SQLEXAMPLE1 -DatabaseName ExampleDB
 
         Return the files for the database specified on the sql server provided.
 
     .EXAMPLE
-        Get-SQLServerDatabaseFiles -SQLServerName SQLEXAMPLE1
+        Get-SQLServerDatabaseFile -SQLServerName SQLEXAMPLE1
 
         Return the files used by all databases in use on the sql server provided.
 

--- a/PSRedgate/public/Get-RedgateSQLBackupError.ps1
+++ b/PSRedgate/public/Get-RedgateSQLBackupError.ps1
@@ -74,7 +74,7 @@ function Get-RedgateSQLBackupError
             Write-Verbose 'Loading error codes from cache file.'
             if (Test-Path $cacheFile)
             {
-                $errorList = Import-Clixml -Path $cacheFile
+                $errorList = Import-CliXML -Path $cacheFile
             }
             else
             {

--- a/PSRedgate/public/Restore-RedgateDatabase.ps1
+++ b/PSRedgate/public/Restore-RedgateDatabase.ps1
@@ -383,6 +383,7 @@ function Restore-RedgateDatabase
                     $options.Add($PSItem.Key, $PSItem.Value)
                 }
 
+                # This will create an undo file so that you can put it into read-only standby mode.
                 if ($PSItem.Key -eq 'READONLY')
                 {
                     $options.Add('STANDBY', "$($StandbyLocation)\UNDO_$DatabaseName.dat")
@@ -401,11 +402,11 @@ function Restore-RedgateDatabase
                     {
                         $SourceSQLServerName = $TargetSQLServerName
                     }
-                    $databaseFiles = Get-SQLServerDatabaseFiles -SQLServerName $SourceSQLServerName -DatabaseName $DatabaseName
+                    $databaseFiles = Get-SQLServerDatabaseFile -SQLServerName $SourceSQLServerName -DatabaseName $DatabaseName
                     if (-not($databaseFiles))
                     {
                         Write-Verbose "Couldn't find file info for $DatabaseName on $SourceSQLServerName. Trying to locate the info on the target $TargetSQLServerName"
-                        $databaseFiles = Get-SQLServerDatabaseFiles -SQLServerName $TargetSQLServerName -DatabaseName $DatabaseName
+                        $databaseFiles = Get-SQLServerDatabaseFile -SQLServerName $TargetSQLServerName -DatabaseName $DatabaseName
                     }
 
                     Write-Verbose "Finding the logical and physical file(s) names for the data so that we can rename the database."


### PR DESCRIPTION
I was using a cmdlet from a private module by mistake. Needed to rename it and refer to it properly.
re-read the style guide, singular is where it's at.
Also consistency is pretty great too